### PR TITLE
Skip "Open README" when running installer silently

### DIFF
--- a/src/installer.in.iss
+++ b/src/installer.in.iss
@@ -30,4 +30,4 @@ Source:"*.md"; DestDir:"{app}"; Flags: ignoreversion
 Source:"*.jpg"; DestDir:"{app}"; Flags: ignoreversion
 
 [Run]
-Filename:"https://github.com/dechamps/FlexASIO/blob/@DECHAMPS_CMAKEUTILS_GIT_DESCRIPTION@/README.md"; Description:"Open README"; Flags: postinstall shellexec nowait
+Filename:"https://github.com/dechamps/FlexASIO/blob/@DECHAMPS_CMAKEUTILS_GIT_DESCRIPTION@/README.md"; Description:"Open README"; Flags: postinstall shellexec nowait skipifsilent


### PR DESCRIPTION
This should (hopefully, because building failed for me) prevent the installer from browsing the github readme when installing silently.