### PR TITLE
Update installer.in.iss to support ARM64

### DIFF
--- a/src/installer.in.iss
+++ b/src/installer.in.iss
@@ -18,7 +18,7 @@ WizardStyle=modern
 
 DefaultDirName={autopf}\FlexASIO
 AppendDefaultDirName=no
-ArchitecturesInstallIn64BitMode=x64
+ArchitecturesInstallIn64BitMode=x64compatible
 
 [Files]
 Source:"install\x64-Release\bin\FlexASIO.dll"; DestDir: "{app}\x64"; Flags: ignoreversion regserver 64bit; Check: Is64BitInstallMode


### PR DESCRIPTION
Release notes Inno Setup 6.3.0:

### Support for Arm64 systems improved, and related enhancements

- Setup now officially supports the installation of x64 apps on Arm64 Windows 11 systems, which are able to run x64 binaries via emulation. To enable your x64 app installers to run properly on Arm64 Windows 11, some minor changes may be needed in your scripts. Most importantly:
  1. In `ArchitecturesAllowed` and `ArchitecturesInstallIn64BitMode`, change any use of `x64` to `x64compatible`.
  2. In `Check` parameters and `[Code]`, change any use of `IsX64` to `IsX64Compatible`.
  3. In `[Code]`, if there are any `ProcessorArchitecture = paX64` comparisons, replace them with calls to `IsX64Compatible`.

  The key difference between `x64/IsX64` and the new `x64compatible/IsX64Compatible` is that the latter matches both x64 Windows and Arm64 Windows 11.
  In most cases, **you should make the above changes**, because otherwise, users on Arm64 systems may not be able to run your installers. For example, an `ArchitecturesAllowed=x64` setting will only allow the installer to run on x64 Windows — not on Arm64 Windows 11. Or, if you ship x86 and x64 versions of your app in the same installer, the 32-bit x86 version may be chosen instead of the expected x64 version when running on Arm64 Windows 11.
- The `[Setup]` section directives `ArchitecturesAllowed` and `ArchitecturesInstallIn64BitMode` have been enhanced:
  - Six new architecture identifiers have been introduced. Briefly:
    - `arm32compatible` matches systems capable of running 32-bit Arm binaries.
    - `x64compatible` matches systems capable of running x64 binaries.
    - `x64os` matches systems running x64 Windows only. (Equivalent to the existing x64 identifier, which is now deprecated.)
    - `x86compatible` matches systems capable of running 32-bit x86 binaries.
    - `x86os` matches systems running 32-bit x86 Windows only. (Equivalent to the existing x86 identifier.)
    - `win64` matches systems running 64-bit Windows, regardless of architecture.
    See the new Architecture Identifiers [help topic](https://jrsoftware.org/ishelp/index.php?topic=archidentifiers) for further details on each.
  - Boolean expressions are now supported. Through use of the `and` operator, for example, it is possible to require two architecture identifiers to match at the same time. See the `ArchitecturesAllowed` [help topic](https://jrsoftware.org/ishelp/index.php?topic=setup_architecturesallowed) for usage examples.
- The `x64` architecture identifier is now deprecated. If it is used, the compiler will issue a warning and substitute `x64os`, which has the same effect. But as mentioned above, in most cases, **scripts should be changed** to use `x64compatible` because it matches both x64 Windows and Arm64 Windows 11.